### PR TITLE
Update canvas to version 1.3.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "node": ">= 0.8"
   },
   "dependencies": {
-    "canvas": "~1.2.0",
+    "canvas": "~1.3.7",
     "graceful-fs": "~1.2.2"
   },
   "scripts": {},


### PR DESCRIPTION
Because of [this issue](https://github.com/Automattic/node-canvas/issues/605) I cannot install resemble on Windows while using VS2015. FIx was released in version [1.3.3](https://github.com/Automattic/node-canvas/pull/670#issuecomment-158661734) of canvas. I haven't tried all possible compatibility issues.
